### PR TITLE
update-doc: mark fzf-zsh clash for vi-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Because fzf is conflict with `zsh-autosuggestions`, so this plugin only enable f
     ```bash
     plugins=(... fzf-zsh ...)
     ```
+    > note: If 'vi-mode' in your plugins, you need add 'fzf-zsh' after the 'vi-mode'. Because both 'fzf-zsh' and 'vi-mode' bind key: '^R'. And you should know, this will mark for 'vi-mode history-incremental-search-backward' invalid(I think you want this).
 
 ### License
 


### PR DESCRIPTION
I discover fzf-zsh flash for vi-mode(oh-my-zsh plugin, it at `$ZSH/plugins/vi-mode`). Both fzf-zsh plugin and vi-mode bind key `^R`, so the back will cover the front.

And `^R` at vi-mode is "history-incremental-search-backward", so we can cover it.

我们 fzf-zsh 是通过 `^R` 方式触发的，如果正好用户也用了 `vi-mode` 的话，`vi-mode`里也注册了 `^R` ，而且功能同样是触发反向搜索，所以要想让 `fzf-zsh` 生效的话就应该加在`vi-mode`后面，就像 `plugins = (....vi-mode.....fzf-zsh)`。因为`fzf-zsh`的功能就是用来覆盖上面这个的，所以刚刚好也可以覆盖这个快捷键的注册